### PR TITLE
Refactor session notes relationship and note handling

### DIFF
--- a/app/Http/Controllers/PsychologyVisits/AdminPsySessionController.php
+++ b/app/Http/Controllers/PsychologyVisits/AdminPsySessionController.php
@@ -63,7 +63,7 @@ class AdminPsySessionController extends Controller
         }
 
         $sessions = $this->sessionService->getAllSessions($filters);
-        $sessions->load(['psychologist', 'patient', 'notes']);
+        $sessions->load(['psychologist', 'patient', 'sessionNotes']);
 
         // Get data for filters
         $psychologists = $this->psychologistService->getAllPsychologists();
@@ -108,7 +108,7 @@ class AdminPsySessionController extends Controller
     {
         try {
             $session = $this->sessionService->getSessionById($id);
-            $session->load(['psychologist', 'patient', 'notes.psychologist']);
+            $session->load(['psychologist', 'patient', 'sessionNotes.psychologist']);
             
             return view('admin.psy-sessions.show', compact('session'));
             

--- a/app/Http/Requests/PsychologyVisits/StorePsyNoteRequest.php
+++ b/app/Http/Requests/PsychologyVisits/StorePsyNoteRequest.php
@@ -14,10 +14,8 @@ class StorePsyNoteRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'psy_session_id' => 'required|exists:psy_sessions,id',
-            'psychologist_id' => 'required|exists:psychologists,id',
             'content' => 'required|string|max:10000',
-            'note_type' => 'sometimes|in:session_notes,assessment,follow_up,treatment_plan,progress_notes,other',
+            'note_type' => 'required|in:session_notes,assessment,follow_up,treatment_plan,progress_notes,other',
             'is_encrypted' => 'sometimes|boolean',
         ];
     }
@@ -25,14 +23,12 @@ class StorePsyNoteRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'psy_session_id.required' => 'Session is required.',
-            'psy_session_id.exists' => 'Selected session does not exist.',
-            'psychologist_id.required' => 'Psychologist is required.',
-            'psychologist_id.exists' => 'Selected psychologist does not exist.',
             'content.required' => 'Note content is required.',
             'content.string' => 'Note content must be text.',
             'content.max' => 'Note content cannot exceed 10,000 characters.',
+            'note_type.required' => 'Note type is required.',
             'note_type.in' => 'Invalid note type.',
+            'is_encrypted.boolean' => 'Encryption setting must be true or false.',
         ];
     }
 }

--- a/app/Models/PsySession.php
+++ b/app/Models/PsySession.php
@@ -46,7 +46,7 @@ class PsySession extends Model
     /**
      * Get all notes for this session
      */
-    public function notes(): HasMany
+    public function sessionNotes(): HasMany
     {
         return $this->hasMany(PsyNote::class);
     }

--- a/app/Services/PsychologyVisits/PsySessionService.php
+++ b/app/Services/PsychologyVisits/PsySessionService.php
@@ -57,7 +57,7 @@ class PsySessionService
      */
     public function getSessionById(int $id): PsySession
     {
-        return PsySession::with(['psychologist', 'patient', 'notes'])->findOrFail($id);
+        return PsySession::with(['psychologist', 'patient', 'sessionNotes'])->findOrFail($id);
     }
 
     /**

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -59,12 +59,7 @@
                                 Sessions
                             </a>
 
-                            <a href="{{ route('admin.psy-notes.index') }}" class="text-gray-500 hover:bg-gray-50 hover:text-gray-700 group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                                <svg class="text-gray-400 mr-3 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-                                </svg>
-                                Notes
-                            </a>
+                           
                         </div>
                     </div>
 

--- a/resources/views/admin/psy-sessions/notes/create.blade.php
+++ b/resources/views/admin/psy-sessions/notes/create.blade.php
@@ -64,6 +64,7 @@
 
                 <!-- Encryption -->
                 <div class="flex items-center">
+                    <input type="hidden" name="is_encrypted" value="0">
                     <input type="checkbox" name="is_encrypted" id="is_encrypted" value="1" {{ old('is_encrypted', true) ? 'checked' : '' }}
                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
                     <label for="is_encrypted" class="ml-2 block text-sm text-gray-900">

--- a/resources/views/admin/psy-sessions/show.blade.php
+++ b/resources/views/admin/psy-sessions/show.blade.php
@@ -152,7 +152,7 @@
     </div>
 
     <!-- Session Notes -->
-    @if($session->notes->count() > 0)
+    @if($session->sessionNotes->count() > 0)
     <div class="mt-6 bg-white shadow overflow-hidden sm:rounded-lg">
         <div class="px-4 py-5 sm:px-6 flex justify-between items-center">
             <div>
@@ -170,7 +170,7 @@
         
         <div class="px-4 py-5 sm:p-6">
             <div class="space-y-4">
-                @foreach($session->notes as $note)
+                @foreach($session->sessionNotes as $note)
                     <div class="border border-gray-200 rounded-lg p-4">
                         <div class="flex justify-between items-start">
                             <div class="flex-1">


### PR DESCRIPTION
Renamed the PsySession model's 'notes' relationship to 'sessionNotes' and updated all related controller, service, and view references. Improved note creation and update logic to use the session's psychologist_id, added logging for note creation, and adjusted validation rules for note type and encryption. Removed unused notes link from the admin dashboard.